### PR TITLE
Fix error "_devices[i] is undefined"

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -68,7 +68,7 @@ const DockerNetworkManager = new Lang.Class({
 				let _devices = _network._devices.wired.devices;
 
 				for ( var i = 0; i < _devices.length; i++) {
-					this._deviceAdded(_devices[i]._getDescription(), _devices[i]);
+					_devices[i] && this._deviceAdded(_devices[i]._getDescription(), _devices[i]);
 				}
 
 				_devices.watch('length', function (property, from, to) {


### PR DESCRIPTION
Gjs-Message: JS LOG: Extension "docker-integration@jan.trejbal.gmail.com" had error: TypeError: _devices[i] is undefined
