### PR TITLE
extension: drop useless libnm-glib import

### DIFF
--- a/src/DockerNetworkManager.js
+++ b/src/DockerNetworkManager.js
@@ -4,7 +4,6 @@ const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 
 const Main = imports.ui.main;
-const NetworkManager = imports.gi.NetworkManager;
 
 const DockerNetworkManager = new Lang.Class({
 	Name : 'DockerNetworkManager',


### PR DESCRIPTION
libnm-glib has been deprecated in favor of libnm for ages. GNOME Shell
seems to be among the last bits to be ported. This is now being done [1]:

[1] https://bugzilla.gnome.org/show_bug.cgi?id=789811

Unfortunately, due to GLib limitations, libnm-glib.so and libnm.so can't
be loaded at the same time and the attempt to do so results in a nasty
crash. The extensions thus needs to be updated to libnm.

This one looks easy -- the libnm-glib is not used at all.